### PR TITLE
Automate TestPyPI/PyPI releases and package install smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,38 @@ jobs:
 
       - name: Build sdist and wheel
         run: uv run python -m build
+
+  package-smoke:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Build wheel
+        run: |
+          uv sync --extra test
+          uv run python -m build --wheel
+
+      - name: Install built wheel with extras and run quickstart smoke
+        run: |
+          python3 -m venv .venv-wheel
+          . .venv-wheel/bin/activate
+          python -m pip install --upgrade pip
+          WHEEL_PATH=$(ls dist/*.whl)
+          WHEEL_URL="file://$(pwd)/${WHEEL_PATH}"
+          python -m pip install "calmplots[all] @ ${WHEEL_URL}"
+          python - <<'PY'
+          import calmplots
+
+          calmplots.apply_matplotlib_theme()
+          calmplots.set_seaborn_theme(context="notebook")
+          calmplots.register_plotly_template(set_default=True)
+          calmplots.enable_altair_theme()
+          print(calmplots.__version__)
+          PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -19,6 +19,24 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
+
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          uv run python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          tag = "${{ github.ref_name }}"
+          pkg_version = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+          tag_version = tag.removeprefix("v")
+
+          if pkg_version != tag_version:
+              raise SystemExit(
+                  f"Tag/version mismatch: tag={tag} pyproject={pkg_version}. "
+                  "Update pyproject.toml or retag before publishing."
+              )
+          PY
 
       - name: Build distributions
         run: |
@@ -33,12 +51,6 @@ jobs:
         with:
           name: dist-artifacts
           path: dist/*
-
-      - name: Publish GitHub release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            dist/*
 
   install-smoke:
     runs-on: ubuntu-latest
@@ -71,6 +83,7 @@ jobs:
   publish-testpypi:
     runs-on: ubuntu-latest
     needs: install-smoke
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       id-token: write
     environment:
@@ -91,6 +104,7 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-latest
     needs: publish-testpypi
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       id-token: write
     environment:
@@ -105,3 +119,22 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-github-release:
+    runs-on: ubuntu-latest
+    needs: publish-pypi
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: dist-artifacts
+          path: dist
+
+      - name: Publish GitHub release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,83 @@ jobs:
           uv sync --extra test
           uv run python -m build
 
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist-artifacts
+          path: dist/*
+
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/*
+
+  install-smoke:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: dist-artifacts
+          path: dist
+
+      - name: Install wheel and run quickstart smoke
+        run: |
+          python3 -m venv .venv-wheel
+          . .venv-wheel/bin/activate
+          python -m pip install --upgrade pip
+          WHEEL_PATH=$(ls dist/*.whl)
+          WHEEL_URL="file://$(pwd)/${WHEEL_PATH}"
+          python -m pip install "calmplots[all] @ ${WHEEL_URL}"
+          python - <<'PY'
+          import calmplots
+
+          calmplots.apply_matplotlib_theme()
+          calmplots.set_seaborn_theme(context="notebook")
+          calmplots.register_plotly_template(set_default=True)
+          calmplots.enable_altair_theme()
+          print(calmplots.__version__)
+          PY
+
+  publish-testpypi:
+    runs-on: ubuntu-latest
+    needs: install-smoke
+    permissions:
+      id-token: write
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/calmplots
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: dist-artifacts
+          path: dist
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    runs-on: ubuntu-latest
+    needs: publish-testpypi
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/calmplots
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: dist-artifacts
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,4 +71,14 @@ For a release:
 
 1. Update version in `pyproject.toml`.
 2. Add release notes in `CHANGELOG.md`.
-3. Create and push a tag (`vX.Y.Z`).
+3. Ensure both GitHub environments exist:
+   - `testpypi` (trusted publisher configured in TestPyPI)
+   - `pypi` (trusted publisher configured in PyPI)
+   - configure `pypi` with required reviewers if you want manual approval before publish
+4. Create and push a tag (`vX.Y.Z`).
+5. The release workflow will:
+   - build wheel/sdist
+   - run `twine check`
+   - run wheel install + quickstart smoke checks
+   - publish to TestPyPI first
+   - publish to PyPI after the TestPyPI gate

--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ For local development with `uv`:
 uv sync --extra all
 ```
 
+Install the latest unreleased code from GitHub:
+
+```bash
+pip install "calmplots @ git+https://github.com/techwizrd/calmplots.git"
+pip install "calmplots[all] @ git+https://github.com/techwizrd/calmplots.git"
+uv add "calmplots @ git+https://github.com/techwizrd/calmplots.git"
+uv add "calmplots[all] @ git+https://github.com/techwizrd/calmplots.git"
+```
+
+For reproducible Git installs, pin to a commit:
+
+```bash
+pip install "calmplots @ git+https://github.com/techwizrd/calmplots.git@<commit_sha>"
+uv add "calmplots @ git+https://github.com/techwizrd/calmplots.git@<commit_sha>"
+```
+
+Note: Git installs may include unreleased changes; use PyPI releases for production.
+
 For docs and test tooling only:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -43,7 +43,21 @@ Accessibility note:
 The base palette set is derived from
 [`blueycolors`](https://github.com/ekholme/blueycolors) by Eric Ekholm.
 
-## Install with uv
+## Install
+
+For most users:
+
+```bash
+pip install calmplots
+```
+
+To install all optional backend integrations:
+
+```bash
+pip install "calmplots[all]"
+```
+
+For local development with `uv`:
 
 ```bash
 uv sync --extra all

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -22,6 +22,24 @@ For local development with `uv`:
 
    uv sync --extra all
 
+Install unreleased code from GitHub:
+
+.. code-block:: bash
+
+   pip install "calmplots @ git+https://github.com/techwizrd/calmplots.git"
+   pip install "calmplots[all] @ git+https://github.com/techwizrd/calmplots.git"
+   uv add "calmplots @ git+https://github.com/techwizrd/calmplots.git"
+   uv add "calmplots[all] @ git+https://github.com/techwizrd/calmplots.git"
+
+For reproducible Git installs, pin to a commit:
+
+.. code-block:: bash
+
+   pip install "calmplots @ git+https://github.com/techwizrd/calmplots.git@<commit_sha>"
+   uv add "calmplots @ git+https://github.com/techwizrd/calmplots.git@<commit_sha>"
+
+Git installs may include unreleased changes; prefer PyPI releases for production.
+
 Apply themes
 ------------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,8 +1,22 @@
 Quickstart
 ==========
 
-Install with uv
----------------
+Install
+-------
+
+For most users:
+
+.. code-block:: bash
+
+   pip install calmplots
+
+To include all optional backend integrations:
+
+.. code-block:: bash
+
+   pip install "calmplots[all]"
+
+For local development with `uv`:
 
 .. code-block:: bash
 

--- a/tests/test_quickstart_docs.py
+++ b/tests/test_quickstart_docs.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_readme_and_docs_include_user_install_commands():
+    readme = Path("README.md").read_text(encoding="utf-8")
+    quickstart = Path("docs/source/quickstart.rst").read_text(encoding="utf-8")
+
+    for text in (readme, quickstart):
+        assert "pip install calmplots" in text
+        assert 'pip install "calmplots[all]"' in text
+
+
+def test_quickstart_python_calls_work_when_extras_are_installed():
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("seaborn")
+    pytest.importorskip("plotly")
+    pytest.importorskip("altair")
+
+    import calmplots
+
+    calmplots.apply_matplotlib_theme()
+    calmplots.set_seaborn_theme(context="notebook")
+    assert calmplots.register_plotly_template(set_default=True) == "calmplots"
+    assert calmplots.enable_altair_theme() == "calmplots"

--- a/tests/test_quickstart_docs.py
+++ b/tests/test_quickstart_docs.py
@@ -12,6 +12,11 @@ def test_readme_and_docs_include_user_install_commands():
     for text in (readme, quickstart):
         assert "pip install calmplots" in text
         assert 'pip install "calmplots[all]"' in text
+        assert "git+https://github.com/techwizrd/calmplots.git" in text
+        assert (
+            'uv add "calmplots @ git+https://github.com/techwizrd/calmplots.git"'
+            in text
+        )
 
 
 def test_quickstart_python_calls_work_when_extras_are_installed():


### PR DESCRIPTION
## Summary
- add a release workflow that builds artifacts, runs `twine check`, performs wheel-install quickstart smoke, then publishes to TestPyPI and PyPI via trusted publishing
- add CI `package-smoke` job to install the built wheel and run quickstart API smoke checks
- update install docs for PyPI and Git URL installs (`pip` and `uv`), and add tests to keep quickstart/install instructions accurate

## Why
This makes releases safer and repeatable, catches packaging/install regressions earlier, and gives a controlled TestPyPI-to-PyPI path for first-time publishing.

## Follow-up setup
- Configure trusted publishers in TestPyPI and PyPI for `.github/workflows/release.yml`.
- Add required reviewers to the `pypi` environment if you want manual approval before production publish.